### PR TITLE
Fix Flutter 3.35.4 compatibility and update package versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,11 +13,11 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_hooks: 0.20.5
-  hooks_riverpod: 2.6.1
-  riverpod_annotation: 2.6.1
+  hooks_riverpod: ^2.6.1
+  riverpod_annotation: ^2.6.1
   gap: 3.0.1
   logger: 2.5.0
-  very_good_analysis: 7.0.0
+  very_good_analysis: ^7.0.0
   # INFO: 個人作成のWidgetパッケージ -> 未使用であれば削除
   utility_widgets:
     git:
@@ -26,17 +26,17 @@ dependencies:
   freezed_annotation: ^2.4.4
   json_annotation: ^4.9.0
   rename_app: ^1.6.1
-  go_router: 14.8.0
+  go_router: ^14.8.0
 
 dev_dependencies:
-  build_runner: 2.4.14
-  riverpod_generator: 2.6.4
-  riverpod_lint: 2.6.4
-  flutter_lints: 5.0.0
+  build_runner: ^2.4.14
+  riverpod_generator: ^2.6.4
+  riverpod_lint: ^2.6.4
+  flutter_lints: ^5.0.0
   flutter_test:
     sdk: flutter
-  freezed: 2.5.8
-  json_serializable: 6.9.5
+  freezed: ^2.5.8
+  json_serializable: ^6.9.5
   flutter_localizations:
     sdk: flutter
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,30 +13,30 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_hooks: 0.20.5
-  hooks_riverpod: ^2.6.1
-  riverpod_annotation: ^2.6.1
+  hooks_riverpod: ">=2.6.1 <2.7.0"
+  riverpod_annotation: ">=2.6.1 <2.7.0"
   gap: 3.0.1
   logger: 2.5.0
-  very_good_analysis: ^7.0.0
+  very_good_analysis: ">=7.0.0 <7.1.0"
   # INFO: 個人作成のWidgetパッケージ -> 未使用であれば削除
   utility_widgets:
     git:
       url: https://github.com/HaruhikoMotokawa/utility_widgets.git
       ref: v1.0.0
-  freezed_annotation: ^2.4.4
-  json_annotation: ^4.9.0
-  rename_app: ^1.6.1
-  go_router: ^14.8.0
+  freezed_annotation: ">=2.4.4 <2.5.0"
+  json_annotation: ">=4.9.0 <4.10.0"
+  rename_app: ">=1.6.1 <1.7.0"
+  go_router: ">=14.8.0 <14.9.0"
 
 dev_dependencies:
-  build_runner: ^2.4.14
-  riverpod_generator: ^2.6.4
-  riverpod_lint: ^2.6.4
-  flutter_lints: ^5.0.0
+  build_runner: ">=2.4.14 <2.5.0"
+  riverpod_generator: ">=2.6.4 <2.7.0"
+  riverpod_lint: ">=2.6.4 <2.7.0"
+  flutter_lints: ">=5.0.0 <5.1.0"
   flutter_test:
     sdk: flutter
-  freezed: ^2.5.8
-  json_serializable: ^6.9.5
+  freezed: ">=2.5.8 <2.6.0"
+  json_serializable: ">=6.9.5 <6.10.0"
   flutter_localizations:
     sdk: flutter
 
@@ -47,7 +47,7 @@ flutter:
 
 scripts:
   # build_runnerを実行して、同じファイル名があれば古いものを削除する
-  build: flutter pub run build_runner build --delete-conflicting-outputs
+  build: dart run build_runner build -d
   # 保存するたびにbuild_runnerを実行して変更を走らせるようになる
   watch: fvm dart run build_runner watch -d
   #  Gradle デーモンプロセスを終了する => ビルドエラーの解消
@@ -60,4 +60,4 @@ scripts:
   reset_flutter: flutter clean && flutter pub cache repair && flutter pub get --no-example
   # 初期設定のスクリプト
   # INFO:実行する前にVScodeの置換機能を使ってConstants.appNameとこのスクリプト内の [ NewAppName ]を任意の名前に変えておく
-  init_app: rm -rf .git && git init && flutter pub run build_runner build --delete-conflicting-outputs && dart run rename_app:main all="NewAppName"
+  init_app: rm -rf .git && git init && dart run build_runner build --delete-conflicting-outputs && dart run rename_app:main all="NewAppName"


### PR DESCRIPTION
## 概要
Flutter 3.35.4への対応とパッケージバージョンの適切な範囲指定を行いました。

## 変更内容

### 1. パッケージバージョンの制限
現在の`pubspec.lock`に基づいて、以下のパッケージのバージョン範囲を適切に制限しました：

- `hooks_riverpod`: `^2.6.1` → `>=2.6.1 <2.7.0`
- `riverpod_annotation`: `^2.6.1` → `>=2.6.1 <2.7.0`
- `very_good_analysis`: `^7.0.0` → `>=7.0.0 <7.1.0`
- `freezed_annotation`: `^2.4.4` → `>=2.4.4 <2.5.0`
- `json_annotation`: `^4.9.0` → `>=4.9.0 <4.10.0`
- `rename_app`: `^1.6.1` → `>=1.6.1 <1.7.0`
- `go_router`: `^14.8.0` → `>=14.8.0 <14.9.0`
- `build_runner`: `^2.4.14` → `>=2.4.14 <2.5.0`
- `riverpod_generator`: `^2.6.4` → `>=2.6.4 <2.7.0`
- `riverpod_lint`: `^2.6.4` → `>=2.6.4 <2.7.0`
- `flutter_lints`: `^5.0.0` → `>=5.0.0 <5.1.0`
- `freezed`: `^2.5.8` → `>=2.5.8 <2.6.0`
- `json_serializable`: `^6.9.5` → `>=6.9.5 <6.10.0`

### 2. 非推奨コマンドの修正
scriptsセクションで使用されていた非推奨の`flutter pub run`を`dart run`に更新しました：

- `build`スクリプト: `flutter pub run build_runner build` → `dart run build_runner build`
- `init_app`スクリプト内の該当箇所も同様に修正

## 効果

### バージョン制限による安定性向上
- マイナーバージョンの変更による予期しない破壊的変更を回避
- パッチバージョンでのセキュリティ修正は受け取れる
- 使用しているバージョン範囲が明確に把握できる

### 非推奨警告の解消
- `dart run`コマンドの使用により、ビルド時の非推奨警告が表示されなくなる
- Flutter 3.3以降の推奨方式に準拠

## テスト結果
✅ `derry build`が正常に実行され、すべてのコードジェネレーションが適切に動作することを確認済み

## 互換性
現在の`pubspec.lock`と完全に互換性を保ちながら、より安全な範囲でのアップデートのみを許可する設定になっています。